### PR TITLE
Prevent apt arch from autoselect, add variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,8 +10,9 @@ docker_compose_version: "1.16.1"
 docker_compose_path: /usr/local/bin/docker-compose
 
 # Used only for Debian/Ubuntu. Switch 'stable' to 'edge' if needed.
+docker_apt_architecture: amd64
 docker_apt_release_channel: stable
-docker_apt_repository: "deb https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
+docker_apt_repository: "deb [arch={{ docker_apt_architecture }}] https://download.docker.com/linux/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} {{ docker_apt_release_channel }}"
 
 # Used only for RedHat/CentOS.
 docker_yum_repo_url: https://download.docker.com/linux/centos/docker-{{ docker_edition }}.repo


### PR DESCRIPTION
There was not a way to partially customize ubuntu preferred arch to install, so it can fail with `No "stable/binary-i386/Packages" in Release file` or user must to redefine full `docker_apt_repository` value.
Variable will fix it without close down of support for other architectures.

[Related commit](https://github.com/geerlingguy/ansible-role-docker/commit/404cfb80d6e0fbcab6f7a04ca6bd56e7819ab535)